### PR TITLE
add header and section for new bugs to the default github issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,9 +1,30 @@
+This is the default new issue template! You may use the next section to enter a new user story, or use the last section to enter a new bug. Please delete this header and the other unused section before submitting this issue.
+
+---
+
 As X, I want Y so that Z.
 
-## Acceptance Criteria 
+## Acceptance Criteria
 
 - [ ] Verify
 
 ## Assumptions and Questions
 
-- 
+-
+
+---
+
+X is a bug because Y happens when I expect Z.
+
+## Steps to Reproduce
+
+1.
+1.
+
+## Expected Result
+
+-
+
+## Actual Result
+
+-


### PR DESCRIPTION
This updates the issue template to match the one used in cloudigrade.