### PR TITLE
Patch for Add Account Modal copy

### DIFF
--- a/src/components/accountWizard/__tests__/__snapshots__/accountWizardStepRole.test.js.snap
+++ b/src/components/accountWizard/__tests__/__snapshots__/accountWizardStepRole.test.js.snap
@@ -35,7 +35,11 @@ exports[`unconnected 1`] = `
         </li>
         <li>
           <p>
-            Paste this value into the Account ID field:
+            Paste this value into the Account ID field under 
+            <strong>
+              Another AWS account
+            </strong>
+            :
           </p>
           <div
             aria-live="polite"

--- a/src/components/accountWizard/accountWizardStepRole.js
+++ b/src/components/accountWizard/accountWizardStepRole.js
@@ -45,7 +45,9 @@ class AccountWizardStepRole extends React.Component {
                 </Tooltip>
               </li>
               <li>
-                <p>Paste this value into the Account ID field:</p>
+                <p>
+                  Paste this value into the Account ID field under <strong>Another AWS account</strong>:
+                </p>
                 <CopyField id="account-id" value={configuration.aws_account_id || ''} />
               </li>
               <li>


### PR DESCRIPTION
In addition to the slightly hidden `help` popover, added bullet level copy noting the use of `Another AWS account`.

* minor copy update to call out Another AWS account
* unit test snapshot updated

![screen shot 2018-07-02 at 3 44 07 pm](https://user-images.githubusercontent.com/3761375/42183325-5fc93070-7e0f-11e8-8fe5-c9f874f3846f.png)

updates #12 
@bclarhk 